### PR TITLE
Fix Chrome autoplay by setting mute flag

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
         :src="bongocat.src.S" :style="{ width: videoSize + 'vw', height: videoSize + 'vh'}">
       </video>
       <iframe v-if="bongocat && bongocat.type.S == 'yt'" type="text/html" allow="autoplay" :style="{ width: videoSize + 'vw', height: videoSize + 'vh'}"
-        :src="`${bongocat.src.S}?autoplay=1&controls=${videoControls ? 1 : 0}&disablekb=1&origin=https://bongocat.io`"
+        :src="`${bongocat.src.S}?autoplay=1&enable_js=1&mute=1&controls=${videoControls ? 1 : 0}&disablekb=1&origin=https://bongocat.io`"
         frameborder="0"></iframe>
     </main>
 

--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
         :src="bongocat.src.S" :style="{ width: videoSize + 'vw', height: videoSize + 'vh'}">
       </video>
       <iframe v-if="bongocat && bongocat.type.S == 'yt'" type="text/html" allow="autoplay" :style="{ width: videoSize + 'vw', height: videoSize + 'vh'}"
-        :src="`${bongocat.src.S}?autoplay=1&enable_js=1&mute=1&controls=${videoControls ? 1 : 0}&disablekb=1&origin=https://bongocat.io`"
+        :src="`${bongocat.src.S}?autoplay=1&mute=1&controls=${videoControls ? 1 : 0}&disablekb=1&origin=https://bongocat.io`"
         frameborder="0"></iframe>
     </main>
 


### PR DESCRIPTION
Hi there!

The latest versions of Chrome block autoplay for videos with sound. To bypass this, I set the mute flag.

Tested locally & the video started playing automatically (Chrome 69.0).